### PR TITLE
feat: Implement M5 UI MVP for Dataset Distiller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+*.egg-info/
+.installed.cfg
+*.egg
+.pytest_cache/
+.mypy_cache/
+.tox/
+.coverage
+.hypothesis/
+pip-wheel-metadata/
+# Node
+node_modules/
+frontend/node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+pnpm-lock.yaml
+
+# IDEs and editors
+.idea/
+.vscode/
+*.swp
+*~
+# OS generated files
+.DS_Store
+Thumbs.db
+# Build artifacts
+dist/
+build/
+out/
+# Logs
+logs/
+*.log

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Dataset Distiller will provide an automated, robust, and extensible solution to 
 *   **Backend:** Python (FastAPI)
 *   **Data Processing:** LangChain, Unstructured.io, Presidio (for PII), custom Python scripts.
 *   **Database:** PostgreSQL (via SQLModel)
-*   **Frontend (M2):** Simple HTML/CSS/JS or a lightweight framework like HTMX or Vue/React if necessary.
+*   **Frontend (M2):** Simple HTML/CSS/JS or a lightweight framework like HTMX or Vue/React if necessary. (Currently React + Vite + Tailwind)
 *   **DevOps:** Docker, GitHub Actions, Pre-commit, Poetry.
 *   **Orchestration (Future):** Potentially LangGraph or a simple job queue like Celery if complexity grows.
 
@@ -80,12 +80,39 @@ poetry install
 cp .env.example .env
 # ... edit .env with your settings ...
 
-# Run database migrations (M2 onwards)
+# Run database migrations (M2 onwards for DB changes)
 # poetry run alembic upgrade head
 
 # Run the application (M2 onwards for UI)
-# poetry run uvicorn backend.main:app --reload
+# poetry run uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
+# For the frontend dev server (if running separately):
+# cd frontend
+# pnpm dev # or npm run dev
 ```
+
+### Running Tests
+
+**Backend Tests (Pytest):**
+```bash
+poetry run pytest backend/tests
+```
+
+**Frontend E2E Tests (Playwright):**
+
+First, ensure Playwright's browsers are installed:
+```bash
+poetry run playwright install --with-deps
+# or from frontend directory: pnpm exec playwright install --with-deps
+```
+
+To run the E2E tests for the frontend:
+```bash
+# From the monorepo root:
+poetry run playwright test -c frontend/playwright.config.ts
+# Alternatively, if you are in the frontend directory:
+# pnpm exec playwright test
+```
+The tests will automatically start the frontend development server. Make sure the backend server (if E2E tests depend on it for API calls not mocked) is running if your tests hit live API endpoints. The current E2E tests use extensive API mocking and should run independently of the live backend.
 
 ## Contributing
 

--- a/frontend/e2e/happy-path.spec.ts
+++ b/frontend/e2e/happy-path.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect, Page } from '@playwright/test';
+import { ClientRead, RoleRead, RoleStatus } from '../src/types'; // Adjust path as needed
+
+const BASE_URL = 'http://localhost:3000'; // Assuming default Vite port, will be overridden by playwright.config.ts
+
+// --- Mock Data ---
+const MOCK_CLIENT_ALPHA_ID = 'uuid-client-alpha';
+const MOCK_CLIENT_BETA_ID = 'uuid-client-beta';
+
+const MOCK_CLIENTS_LIST: ClientRead[] = [
+  { id: MOCK_CLIENT_ALPHA_ID, display_name: 'Client Alpha', notes: 'Notes for Alpha', created_at: '2023-01-01T10:00:00Z' },
+  { id: MOCK_CLIENT_BETA_ID, display_name: 'Client Beta', notes: null, created_at: '2023-01-02T11:00:00Z' },
+];
+
+const MOCK_ROLE_PARSED_ID = 'uuid-role-parsed';
+const MOCK_ROLE_VERIFIED_ID = 'uuid-role-verified';
+
+const MOCK_ROLES_FOR_ALPHA: RoleRead[] = [
+  {
+    id: MOCK_ROLE_PARSED_ID,
+    client_id: MOCK_CLIENT_ALPHA_ID,
+    company_name: 'Old Company',
+    title: 'Old Title',
+    start_date: '2022-01-01',
+    end_date: '2022-12-31',
+    output_text: 'Some output text for Old Company.',
+    status: RoleStatus.Parsed,
+    revision: 1,
+    input_text_compact: 'Initial compact text for Old Company',
+    created_at: '2023-01-01T10:00:00Z',
+    updated_at: '2023-01-01T10:00:00Z',
+  },
+  {
+    id: MOCK_ROLE_VERIFIED_ID,
+    client_id: MOCK_CLIENT_ALPHA_ID,
+    company_name: 'Verified Solutions',
+    title: 'Verified Engineer',
+    start_date: '2021-06-01',
+    end_date: null,
+    output_text: 'Output for Verified Solutions.',
+    status: RoleStatus.RolesVerified, // Suitable for HITL 2 (curation)
+    revision: 2,
+    input_text_compact: 'Initial compact text for Verified Solutions',
+    created_at: '2023-01-01T11:00:00Z',
+    updated_at: '2023-01-01T12:00:00Z',
+  },
+];
+
+// --- Test Suite ---
+test.describe('Happy Path E2E Tests', () => {
+
+  test.beforeEach(async ({ page }) => {
+    // Common setup:
+    // Mock generic client list for any navigation to `/`
+    await page.route(`/api/clients`, async route => {
+      await route.fulfill({ json: MOCK_CLIENTS_LIST });
+    });
+
+    // Mock specific client details (can be overridden in specific tests if needed)
+    await page.route(`/api/clients/${MOCK_CLIENT_ALPHA_ID}`, async route => {
+      const client = MOCK_CLIENTS_LIST.find(c => c.id === MOCK_CLIENT_ALPHA_ID);
+      if (client) {
+        await route.fulfill({ json: client });
+      } else {
+        await route.fulfill({ status: 404, json: { message: 'Client not found' } });
+      }
+    });
+
+    // Mock roles for Client Alpha (can be overridden)
+    await page.route(`/api/clients/${MOCK_CLIENT_ALPHA_ID}/roles`, async route => {
+      await route.fulfill({ json: MOCK_ROLES_FOR_ALPHA });
+    });
+  });
+
+  test('Test 1: Client List and Navigation', async ({ page }) => {
+    await page.goto('/');
+
+    // Assert title or heading
+    await expect(page.getByRole('heading', { name: 'Clients', level: 1 })).toBeVisible();
+
+    // Assert client names are visible
+    await expect(page.getByText('Client Alpha')).toBeVisible();
+    await expect(page.getByText('Client Beta')).toBeVisible();
+
+    // Action: Click on the first client
+    // Assuming the link is directly on the text or a card containing it
+    await page.getByText('Client Alpha').click();
+
+    // Assert URL changes
+    await expect(page).toHaveURL(`/client/${MOCK_CLIENT_ALPHA_ID}`);
+
+    // Assert client detail page indication
+    // This could be the client's name in a heading or a specific title
+    await expect(page.getByRole('heading', { name: 'Client Alpha', level: 1 })).toBeVisible();
+    // Or more specific if there's a title like "Client Details"
+    // await expect(page.getByRole('heading', { name: /Client.*Details/i })).toBeVisible();
+  });
+
+
+  test('Test 2: Role Verification and Basic Editing (HITL 1)', async ({ page }) => {
+    await page.goto(`/client/${MOCK_CLIENT_ALPHA_ID}`);
+
+    // Assert initial role information is visible
+    await expect(page.getByText('Old Company')).toBeVisible();
+    await expect(page.getByText('Old Title')).toBeVisible();
+    await expect(page.getByText('Status: Parsed')).toBeVisible();
+
+    // Action: Click an "Edit" button for the first role
+    // Assuming the button is specific to the role card for "Old Company"
+    // We use a more robust locator strategy: find the role container, then the button within it.
+    const roleContainer = page.locator('.space-y-6 > div', { hasText: 'Old Company' }).first();
+    await roleContainer.getByRole('button', { name: 'Edit Details' }).click();
+
+    // Assert editing UI is visible
+    await expect(roleContainer.getByLabel('Company Name')).toBeVisible();
+
+    // Action: Fill in a new company name
+    const newCompanyName = 'New Company Inc.';
+    await roleContainer.getByLabel('Company Name').fill(newCompanyName);
+
+    // Mock API for PATCH /api/roles/role-uuid-A
+    let patchPayload: any = null;
+    await page.route(`/api/roles/${MOCK_ROLE_PARSED_ID}`, async route => {
+      if (route.request().method() === 'PATCH') {
+        patchPayload = await route.request().postDataJSON();
+        const updatedRole: RoleRead = {
+          ...MOCK_ROLES_FOR_ALPHA.find(r => r.id === MOCK_ROLE_PARSED_ID)!,
+          company_name: newCompanyName,
+          status: RoleStatus.RolesVerified,
+          revision: patchPayload.revision + 1, // Assuming backend increments revision
+        };
+        await route.fulfill({ json: updatedRole });
+      } else {
+        await route.continue(); // Continue for other methods if any
+      }
+    });
+
+    // Action: Click the "Save & Verify Role" button
+    await roleContainer.getByRole('button', { name: 'Save & Verify Role' }).click();
+
+    // Assert the role's displayed company name updates
+    await expect(roleContainer.getByText(newCompanyName)).toBeVisible();
+    // Assert status updates (text might be part of a larger string)
+    await expect(roleContainer.getByText('Status: RolesVerified')).toBeVisible();
+
+    // Optional: Assert the PATCH payload was as expected
+    expect(patchPayload).toBeTruthy();
+    expect(patchPayload.company_name).toBe(newCompanyName);
+    expect(patchPayload.status).toBe(RoleStatus.RolesVerified);
+    expect(patchPayload.revision).toBe(1); // Original revision sent
+  });
+
+
+  test('Test 3: Role Editor Interaction (HITL 2 - input_text_compact)', async ({ page }) => {
+    // Ensure we are on the client detail page where the target role exists.
+    // The target role for curation is MOCK_ROLE_VERIFIED_ID ('Verified Solutions')
+    // which already has status RolesVerified and revision 2.
+    await page.goto(`/client/${MOCK_CLIENT_ALPHA_ID}`);
+
+    const roleToCurateContainer = page.locator('.space-y-6 > div', { hasText: 'Verified Solutions' }).first();
+
+    // Assert initial state of the role meant for curation
+    await expect(roleToCurateContainer.getByText('Verified Solutions')).toBeVisible();
+    await expect(roleToCurateContainer.getByText('Status: RolesVerified')).toBeVisible(); // Initial status
+
+    // Action: Click the "Curate Input Text" button for this role
+    await roleToCurateContainer.getByRole('button', { name: 'Curate Input Text' }).click();
+
+    // Assert: The RoleEditor component becomes visible (e.g., a textarea)
+    // The RoleEditor has a specific heading.
+    await expect(roleToCurateContainer.getByRole('heading', { name: 'Curate Input Text (HITL 2)'})).toBeVisible();
+    const textarea = roleToCurateContainer.getByPlaceholder('Enter or edit the compact input text for this role...');
+    await expect(textarea).toBeVisible();
+    await expect(textarea).toBeEditable();
+
+    // Action: Type new curated input text
+    const newCuratedText = 'This is new curated input text.';
+    await textarea.fill(newCuratedText);
+
+    // Assert: The token counter updates.
+    // The fallback estimator counts words and punctuation. "This is new curated input text." = 7 words + 1 period = 8 tokens.
+    await expect(roleToCurateContainer.getByText(/Token Count: 8 \/ 8096/)).toBeVisible();
+
+    // Mock API for PATCH /api/roles/MOCK_ROLE_VERIFIED_ID
+    let curatePatchPayload: any = null;
+    await page.route(`/api/roles/${MOCK_ROLE_VERIFIED_ID}`, async route => {
+      if (route.request().method() === 'PATCH') {
+        curatePatchPayload = await route.request().postDataJSON();
+        const updatedRole: RoleRead = {
+          ...MOCK_ROLES_FOR_ALPHA.find(r => r.id === MOCK_ROLE_VERIFIED_ID)!,
+          input_text_compact: newCuratedText,
+          status: RoleStatus.InputCurated,
+          revision: curatePatchPayload.revision + 1,
+        };
+        await route.fulfill({ json: updatedRole });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // Action: Click the "Save Curation" button
+    await roleToCurateContainer.getByRole('button', { name: 'Save Curation' }).click();
+
+    // Assert: The input_text_compact (if displayed on the main role card) updates,
+    // and the role's status changes to "InputCurated".
+    // The RoleEditor should disappear.
+    await expect(roleToCurateContainer.getByRole('heading', { name: 'Curate Input Text (HITL 2)'})).not.toBeVisible();
+
+    // Assert updated status on the card
+    await expect(roleToCurateContainer.getByText('Status: InputCurated')).toBeVisible();
+    // Assert updated text is shown (if UI displays it - ClientDetailPage was updated to show it)
+    await expect(roleToCurateContainer.getByText(newCuratedText)).toBeVisible();
+
+
+    // Optional: Assert the PATCH payload was as expected
+    expect(curatePatchPayload).toBeTruthy();
+    expect(curatePatchPayload.input_text_compact).toBe(newCuratedText);
+    expect(curatePatchPayload.status).toBe(RoleStatus.InputCurated);
+    expect(curatePatchPayload.revision).toBe(2); // Original revision for this role
+  });
+
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host",
+    "build": "tsc && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@tanstack/react-query": "^5.0.0",
+    "gpt-tokenizer": "^2.1.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@types/react-router-dom": "5.3.3",
+    "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "@typescript-eslint/parser": "^7.2.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.6",
+    "postcss": "^8.4.38",
+    "react-router-dom": "^7.6.2",
+    "tailwindcss": "^4.1.8",
+    "typescript": "^5.2.2",
+    "vite": "^5.2.0",
+    "vite-plugin-eslint": "^1.8.1",
+    "eslint-config-react-app": "^7.0.1",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
+    "eslint-plugin-react": "^7.34.1"
+  }
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,67 @@
+import { defineConfig, devices } from '@playwright/test';
+import path from 'path';
+
+// Define the path to the frontend directory relative to this config file
+const frontendDir = __dirname; // This config is in frontend/, so __dirname is frontend/
+
+export default defineConfig({
+  // Look for test files in the "e2e" directory, relative to the configuration file.
+  testDir: path.join(frontendDir, 'e2e'),
+
+  // Each test is given 30 seconds.
+  timeout: 30 * 1000,
+
+  // Forbid test.only on CI
+  forbidOnly: !!process.env.CI,
+
+  // Retry on CI only.
+  retries: process.env.CI ? 2 : 0,
+
+  // Limit the number of workers on CI, use default locally
+  workers: process.env.CI ? 1 : undefined,
+
+  // Reporter to use
+  reporter: 'html',
+
+  use: {
+    // Base URL to use in actions like `await page.goto('/')`.
+    baseURL: 'http://localhost:3000', // Vite's default port
+
+    // Collect trace when retrying the failed test.
+    trace: 'on-first-retry',
+  },
+
+  // Configure projects for major browsers.
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+  ],
+
+  // Run your local dev server before starting the tests.
+  webServer: {
+    // Command to start the dev server.
+    // It's crucial that this command correctly starts your frontend application.
+    // Assuming pnpm is available and you're running tests from the monorepo root
+    // or that pnpm can find the frontend workspace.
+    // The CWD for this command is the directory where `playwright test` is run.
+    // If running `pnpm exec playwright test -c frontend/playwright.config.ts` from root,
+    // then CWD is root.
+    command: 'pnpm --filter frontend dev --port 3000 --host',
+    url: 'http://localhost:3000', // URL to wait for before starting tests
+    reuseExistingServer: !process.env.CI, // Reuse server locally, start new on CI
+    cwd: path.resolve(frontendDir, '..'), // Run pnpm from the monorepo root directory
+    timeout: 120 * 1000, // Increase timeout for web server to start
+    // stdout: 'pipe', // Capture stdout
+    // stderr: 'pipe', // Capture stderr
+  },
+});

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import ClientListPage from './pages/ClientListPage';
+import ClientDetailPage from './pages/ClientDetailPage';
+
+const App: React.FC = () => {
+  return (
+    <Router>
+      <Routes>
+        <Route path="/" element={<ClientListPage />} />
+        <Route path="/client/:clientId" element={<ClientDetailPage />} />
+      </Routes>
+    </Router>
+  );
+};
+
+export default App;

--- a/frontend/src/components/RoleEditor.tsx
+++ b/frontend/src/components/RoleEditor.tsx
@@ -1,0 +1,140 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { RoleRead, RoleStatus } from '../types';
+
+// Simple fallback tokenizer (counts words and punctuation)
+const estimateTokens = (text: string): number => {
+  if (!text) return 0;
+  // Matches words and common punctuation as separate tokens
+  const tokens = text.match(/[\w'-]+|[.,!?;:]/g);
+  return tokens ? tokens.length : 0;
+};
+
+// PII Patterns (examples)
+const PII_PATTERNS: { name: string; regex: RegExp }[] = [
+  { name: 'Email', regex: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g },
+  { name: 'SSN (Example)', regex: /\b\d{3}-\d{2}-\d{4}\b/g },
+  // Add more patterns from sensitive_patterns.py as needed
+  { name: 'Phone (US Example)', regex: /\b\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g }
+];
+
+const MAX_TOKENS = 8096;
+const WARNING_TOKENS = 7500;
+
+interface RoleEditorProps {
+  role: Pick<RoleRead, 'id' | 'input_text_compact' | 'revision' | 'status'>; // Only relevant parts of the role
+  onSave: (updatedData: { input_text_compact: string; revision: number; newStatus: RoleStatus }) => Promise<void>;
+  onCancel: () => void; // To close or hide the editor
+  isSaving: boolean; // To disable button during save
+}
+
+const RoleEditor: React.FC<RoleEditorProps> = ({ role, onSave, onCancel, isSaving }) => {
+  const [currentInputText, setCurrentInputText] = useState<string>(role.input_text_compact || '');
+  const [tokenCount, setTokenCount] = useState<number>(0);
+  const [piiWarnings, setPiiWarnings] = useState<string[]>([]);
+
+  useEffect(() => {
+    setCurrentInputText(role.input_text_compact || '');
+  }, [role.input_text_compact]);
+
+  useEffect(() => {
+    // Debounce token counting and PII check slightly for better performance
+    const handler = setTimeout(() => {
+      const count = estimateTokens(currentInputText);
+      setTokenCount(count);
+
+      const warnings: string[] = [];
+      PII_PATTERNS.forEach(pattern => {
+        // Reset regex state for global flags
+        pattern.regex.lastIndex = 0;
+        if (pattern.regex.test(currentInputText)) {
+          warnings.push(`Potential ${pattern.name} detected.`);
+        }
+      });
+      setPiiWarnings(warnings);
+    }, 300); // 300ms debounce
+
+    return () => clearTimeout(handler);
+  }, [currentInputText]);
+
+  const handleSave = () => {
+    if (tokenCount > MAX_TOKENS) {
+      // This should ideally be prevented by disabling the button
+      alert("Cannot save: token count exceeds maximum limit.");
+      return;
+    }
+    onSave({
+      input_text_compact: currentInputText,
+      revision: role.revision,
+      newStatus: RoleStatus.InputCurated, // Set status to InputCurated upon saving curated text
+    });
+  };
+
+  const tokenCountColor = useMemo(() => {
+    if (tokenCount > MAX_TOKENS) return 'text-red-600 font-bold';
+    if (tokenCount > WARNING_TOKENS) return 'text-yellow-600 font-semibold';
+    return 'text-gray-600';
+  }, [tokenCount]);
+
+  const isSaveDisabled = tokenCount > MAX_TOKENS || isSaving;
+
+  return (
+    <div className="p-4 bg-gray-50 rounded-lg shadow space-y-4">
+      <h3 className="text-lg font-semibold text-gray-800">Curate Input Text (HITL 2)</h3>
+      <p className="text-sm text-gray-600">
+        Edit the compact input text below. This text will be used for further processing or analysis.
+        Original Status: <span className="font-medium">{role.status}</span>
+      </p>
+
+      <textarea
+        value={currentInputText}
+        onChange={(e) => setCurrentInputText(e.target.value)}
+        className="w-full h-60 p-3 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm whitespace-pre-wrap"
+        placeholder="Enter or edit the compact input text for this role..."
+      />
+
+      <div className="flex justify-between items-center">
+        <div className={`text-sm ${tokenCountColor}`}>
+          Token Count: {tokenCount} / {MAX_TOKENS}
+          {tokenCount > WARNING_TOKENS && tokenCount <= MAX_TOKENS && (
+            <span className="ml-2 text-yellow-700">(Approaching limit)</span>
+          )}
+           {tokenCount > MAX_TOKENS && (
+            <span className="ml-2 text-red-700">(Exceeded limit!)</span>
+          )}
+        </div>
+      </div>
+
+      {piiWarnings.length > 0 && (
+        <div className="p-3 bg-yellow-50 border border-yellow-300 rounded-md">
+          <h4 className="text-sm font-semibold text-yellow-800 mb-1">Potential PII Detected:</h4>
+          <ul className="list-disc list-inside text-xs text-yellow-700">
+            {piiWarnings.map((warning, index) => (
+              <li key={index}>{warning}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="flex justify-end space-x-3 mt-4">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isSaving}
+          className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-200 hover:bg-gray-300 rounded-md shadow-sm disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={isSaveDisabled}
+          className="px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-md shadow-sm disabled:bg-green-300"
+        >
+          {isSaving ? 'Saving...' : 'Save Curation'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default RoleEditor;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
+  /* Additional base styles can go here if needed */
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Create a client
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/ClientDetailPage.tsx
+++ b/frontend/src/pages/ClientDetailPage.tsx
@@ -1,0 +1,283 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { ClientRead, RoleRead, RoleUpdate, RoleStatus, ApiError } from '../types';
+import RoleEditor from '../components/RoleEditor';
+
+// Helper to format date strings (YYYY-MM-DD) for input type="date"
+const formatDateForInput = (dateString: string | null | undefined): string => {
+  if (!dateString) return '';
+  try {
+    return new Date(dateString).toISOString().split('T')[0];
+  } catch (e) {
+    return ''; // Handle invalid date string
+  }
+};
+
+const fetchClient = async (clientId: string): Promise<ClientRead> => {
+  const response = await fetch(`/api/clients/${clientId}`);
+  if (!response.ok) {
+    const errorData: ApiError = await response.json().catch(() => ({ message: 'An unknown error occurred' }));
+    throw new Error(errorData.message || `Error ${response.status}: ${response.statusText}`);
+  }
+  return response.json();
+};
+
+const fetchRoles = async (clientId: string): Promise<RoleRead[]> => {
+  const response = await fetch(`/api/clients/${clientId}/roles`);
+  if (!response.ok) {
+    const errorData: ApiError = await response.json().catch(() => ({ message: 'An unknown error occurred' }));
+    throw new Error(errorData.message || `Error ${response.status}: ${response.statusText}`);
+  }
+  return response.json();
+};
+
+// Generic update function, payload determines what's updated
+const updateRoleMutationFn = async ({ roleId, payload }: { roleId: string; payload: RoleUpdate }): Promise<RoleRead> => {
+  const response = await fetch(`/api/roles/${roleId}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const errorData: ApiError = await response.json().catch(() => ({ message: 'An unknown error occurred' }));
+    throw new Error(errorData.message || `Error ${response.status}: ${response.statusText}`);
+  }
+  return response.json();
+};
+
+
+const ClientDetailPage: React.FC = () => {
+  const { clientId } = useParams<{ clientId: string }>();
+  const queryClient = useQueryClient();
+
+  // State for editing role details (company, title, dates)
+  const [editingRole, setEditingRole] = useState<Partial<RoleRead> & { revision: number } | null>(null);
+  // State for editing input_text_compact (curation)
+  const [editingCurationForRoleId, setEditingCurationForRoleId] = useState<string | null>(null);
+
+  const [focusedRoleIndex, setFocusedRoleIndex] = useState<number | null>(null);
+  const roleRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  const { data: client, isLoading: isLoadingClient, error: clientError } = useQuery<ClientRead, Error>({
+    queryKey: ['client', clientId],
+    queryFn: () => fetchClient(clientId!),
+    enabled: !!clientId,
+  });
+
+  const { data: roles, isLoading: isLoadingRoles, error: rolesError } = useQuery<RoleRead[], Error>({
+    queryKey: ['roles', clientId],
+    queryFn: () => fetchRoles(clientId!),
+    enabled: !!clientId,
+  });
+
+  const currentRoleForCuration = roles?.find(r => r.id === editingCurationForRoleId);
+
+  const roleUpdateMutation = useMutation<RoleRead, Error, { roleId: string; payload: RoleUpdate }>({
+    mutationFn: updateRoleMutationFn,
+    onSuccess: (updatedRole) => {
+      queryClient.setQueryData(['roles', clientId], (oldData: RoleRead[] | undefined) =>
+        oldData ? oldData.map(r => r.id === updatedRole.id ? updatedRole : r) : []
+      );
+      // queryClient.invalidateQueries({ queryKey: ['roles', clientId] }); // Consider more targeted invalidation or rely on setQueryData for immediate feedback
+      setEditingRole(null);
+      setEditingCurationForRoleId(null); // Close RoleEditor on successful save
+    },
+    // onError: (error) => { /* Handled by isError and error properties on the mutation hook */ }
+  });
+
+  useEffect(() => {
+    if (roles && roles.length > 0 && editingRole === null && editingCurationForRoleId === null) { // Only adjust focus if not actively editing
+      const firstUnverifiedIndex = roles.findIndex(r => r.status === RoleStatus.Parsed || r.status === RoleStatus.Pending);
+      const newFocusedIndex = firstUnverifiedIndex !== -1 ? firstUnverifiedIndex : 0;
+      if (focusedRoleIndex !== newFocusedIndex) { // Avoid redundant scrolling if focus is already correct
+            setFocusedRoleIndex(newFocusedIndex);
+            roleRefs.current[newFocusedIndex]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }
+  }, [roles, editingRole, editingCurationForRoleId, focusedRoleIndex]);
+
+   useEffect(() => {
+    if (roles) {
+      roleRefs.current = roleRefs.current.slice(0, roles.length);
+    }
+  }, [roles]);
+
+  const handleEditRoleDetails = (role: RoleRead) => {
+    setEditingCurationForRoleId(null); // Ensure curation editor is closed
+    setEditingRole({ ...role });
+  };
+
+  const handleCancelEditRoleDetails = () => {
+    setEditingRole(null);
+  };
+
+  const handleRoleDetailsInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    if (!editingRole) return;
+    const { name, value } = e.target;
+    setEditingRole(prev => ({ ...prev!, [name]: value }));
+  };
+
+  const handleRoleDetailsDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!editingRole) return;
+    const { name, value } = e.target;
+    setEditingRole(prev => ({ ...prev!, [name]: value ? value : null }));
+  };
+
+  const handleSaveRoleDetails = (roleToSave: Partial<RoleRead> & { revision: number }) => {
+    if (!roleToSave || !roleToSave.id) return;
+    const payload: RoleUpdate = {
+      company_name: roleToSave.company_name,
+      title: roleToSave.title,
+      start_date: roleToSave.start_date || null,
+      end_date: roleToSave.end_date || null,
+      status: RoleStatus.RolesVerified,
+      revision: roleToSave.revision,
+    };
+    roleUpdateMutation.mutate({ roleId: roleToSave.id, payload });
+  };
+
+  // --- Curation Specific Handlers ---
+  const handleOpenCurationEditor = (role: RoleRead) => {
+    setEditingRole(null); // Ensure role details editor is closed
+    setEditingCurationForRoleId(role.id);
+  };
+
+  const handleCancelCuration = () => {
+    setEditingCurationForRoleId(null);
+  };
+
+  const handleSaveCuration = async (updatedData: { input_text_compact: string; revision: number; newStatus: RoleStatus }) => {
+    if (!editingCurationForRoleId) return;
+    const payload: RoleUpdate = {
+      input_text_compact: updatedData.input_text_compact,
+      status: updatedData.newStatus,
+      revision: updatedData.revision,
+    };
+    await roleUpdateMutation.mutateAsync({ roleId: editingCurationForRoleId, payload });
+    // onSuccess in useMutation handles closing the editor
+  };
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handleKeyPress = (event: KeyboardEvent) => {
+      if (event.key === 'Enter' && focusedRoleIndex !== null && roles && roles.length > 0) {
+        if (!editingRole && !editingCurationForRoleId) { // Only move if not in any editing mode
+          event.preventDefault();
+          const nextIndex = (focusedRoleIndex + 1) % roles.length;
+          setFocusedRoleIndex(nextIndex);
+          roleRefs.current[nextIndex]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          roleRefs.current[nextIndex]?.focus();
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyPress);
+    return () => window.removeEventListener('keydown', handleKeyPress);
+  }, [focusedRoleIndex, roles, editingRole, editingCurationForRoleId]);
+
+  if (isLoadingClient || isLoadingRoles) return <div className="container mx-auto p-4 text-center">Loading client and roles data...</div>;
+  if (clientError) return <div className="container mx-auto p-4 text-red-500">Error loading client: {clientError.message}</div>;
+
+  return (
+    <div className="container mx-auto p-4">
+      {client && (
+        <div className="mb-8 p-4 border border-gray-300 rounded-lg shadow">
+          <h1 className="text-3xl font-bold mb-2">{client.display_name}</h1>
+          {/* ... other client details ... */}
+        </div>
+      )}
+
+      <h2 className="text-2xl font-semibold mb-4">Role Verification & Curation</h2>
+
+      {rolesError && <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">Error: {rolesError.message}</div>}
+
+      {roles && roles.length === 0 && !rolesError && <p className="text-gray-500">No roles found.</p>}
+
+      {roles && roles.length > 0 && (
+        <div className="space-y-6">
+          {roles.map((role, index) => (
+            <div
+              key={role.id}
+              ref={el => roleRefs.current[index] = el}
+              tabIndex={-1}
+              className={`rounded-lg shadow-md transition-all duration-200 ease-in-out
+                ${focusedRoleIndex === index && !editingRole && !editingCurationForRoleId ? 'ring-2 ring-blue-500' : 'border border-gray-200'}
+                ${editingRole?.id === role.id ? 'bg-blue-50 p-6' : editingCurationForRoleId === role.id ? 'bg-green-50 p-0' : 'bg-white p-6'}`}
+            >
+              {editingRole?.id === role.id ? (
+                // --- Editing Role Details Form ---
+                <div className="space-y-4">
+                  {/* ... form for company_name, title, dates ... (as before) ... */}
+                  <div><label className="block text-sm font-medium text-gray-700">Company Name</label><input type="text" name="company_name" value={editingRole.company_name || ''} onChange={handleRoleDetailsInputChange} className="mt-1 block w-full input-class" /></div>
+                  <div><label className="block text-sm font-medium text-gray-700">Title</label><input type="text" name="title" value={editingRole.title || ''} onChange={handleRoleDetailsInputChange} className="mt-1 block w-full input-class" /></div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div><label className="block text-sm font-medium text-gray-700">Start Date</label><input type="date" name="start_date" value={formatDateForInput(editingRole.start_date)} onChange={handleRoleDetailsDateChange} className="mt-1 block w-full input-class" /></div>
+                    <div><label className="block text-sm font-medium text-gray-700">End Date</label><input type="date" name="end_date" value={formatDateForInput(editingRole.end_date)} onChange={handleRoleDetailsDateChange} className="mt-1 block w-full input-class" /></div>
+                  </div>
+                  <p className="text-sm text-gray-600">Status: <span className="font-semibold">{editingRole.status}</span> (will be updated to RolesVerified)</p>
+                  <p className="text-sm text-gray-600">Revision: {editingRole.revision}</p>
+                  <div className="mt-4"><h4 className="text-md font-semibold text-gray-700 mb-1">Raw Output Text (Read-only):</h4><div className="p-3 bg-gray-100 rounded-md max-h-40 overflow-y-auto text-sm whitespace-pre-wrap">{role.output_text}</div></div>
+                  <div className="flex justify-end space-x-3 mt-6">
+                    <button onClick={handleCancelEditRoleDetails} className="btn-secondary">Cancel</button>
+                    <button onClick={() => handleSaveRoleDetails(editingRole)} disabled={roleUpdateMutation.isPending && editingRole?.id === role.id} className="btn-primary">
+                      {roleUpdateMutation.isPending && editingRole?.id === role.id ? 'Saving...' : 'Save & Verify Role'}
+                    </button>
+                  </div>
+                </div>
+              ) : editingCurationForRoleId === role.id && currentRoleForCuration ? (
+                // --- Editing Curation Text ---
+                <RoleEditor
+                  role={{ id: currentRoleForCuration.id, input_text_compact: currentRoleForCuration.input_text_compact, revision: currentRoleForCuration.revision, status: currentRoleForCuration.status }}
+                  onSave={handleSaveCuration}
+                  onCancel={handleCancelCuration}
+                  isSaving={roleUpdateMutation.isPending && editingCurationForRoleId === role.id}
+                />
+              ) : (
+                // --- Display State for Role ---
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-x-6">
+                  <div className="md:col-span-2 space-y-3">
+                    <h3 className="text-xl font-semibold text-blue-700">{role.company_name}</h3>
+                    <p className="text-md text-gray-800">{role.title}</p>
+                    <p className="text-sm text-gray-600">{role.start_date ? formatDateForInput(role.start_date) : 'N/A'} - {role.end_date ? formatDateForInput(role.end_date) : 'Present'}</p>
+                    <p className={`text-sm font-medium px-2 py-1 inline-block rounded-full ${ role.status === RoleStatus.RolesVerified ? 'bg-green-100 text-green-800' : role.status === RoleStatus.InputCurated ? 'bg-blue-100 text-blue-800' : role.status === RoleStatus.Parsed ? 'bg-yellow-100 text-yellow-800' : 'bg-gray-100 text-gray-800'}`}>Status: {role.status}</p>
+                    <p className="text-xs text-gray-500">Revision: {role.revision}</p>
+                    <div className="flex space-x-2 mt-4">
+                        <button onClick={() => handleEditRoleDetails(role)} className="btn-secondary text-sm">Edit Details</button>
+                        <button onClick={() => handleOpenCurationEditor(role)} className="btn-secondary text-sm">Curate Input Text</button>
+                    </div>
+                  </div>
+                  <div className="md:col-span-1 mt-4 md:mt-0">
+                    <h4 className="text-sm font-semibold text-gray-700 mb-1">Raw Output Text:</h4>
+                    <div className="p-3 bg-gray-50 rounded-md max-h-48 overflow-y-auto text-xs text-gray-600 whitespace-pre-wrap border">{role.output_text}</div>
+                    {role.input_text_compact && (
+                        <div className="mt-2">
+                            <h4 className="text-sm font-semibold text-gray-700 mb-1">Curated Input Text:</h4>
+                            <div className="p-3 bg-gray-50 rounded-md max-h-32 overflow-y-auto text-xs text-gray-600 whitespace-pre-wrap border">{role.input_text_compact}</div>
+                        </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+       {roleUpdateMutation.isError && (
+        <div className="mt-6 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+          <strong className="font-bold">Update Error!</strong>
+          <span className="block sm:inline"> {roleUpdateMutation.error?.message || 'Failed to update role.'}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Minimalistic CSS classes to be defined in index.css or as Tailwind utility compositions if preferred
+// .input-class { @apply mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm; }
+// .btn-primary { @apply px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md shadow-sm disabled:bg-blue-300; }
+// .btn-secondary { @apply px-4 py-2 text-sm font-medium text-gray-700 bg-gray-200 hover:bg-gray-300 rounded-md shadow-sm disabled:opacity-50; }
+
+
+export default ClientDetailPage;

--- a/frontend/src/pages/ClientListPage.tsx
+++ b/frontend/src/pages/ClientListPage.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { ClientRead, ApiError } from '../types';
+
+const fetchClients = async (): Promise<ClientRead[]> => {
+  const response = await fetch('/api/clients');
+  if (!response.ok) {
+    const errorData: ApiError = await response.json().catch(() => ({ message: 'An unknown error occurred' }));
+    throw new Error(errorData.message || `Error ${response.status}: ${response.statusText}`);
+  }
+  return response.json();
+};
+
+const ClientListPage: React.FC = () => {
+  const { data: clients, isLoading, error, isError } = useQuery<ClientRead[], Error>({
+    queryKey: ['clients'],
+    queryFn: fetchClients,
+  });
+
+  return (
+    <div className="container mx-auto p-4">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-bold">Clients</h1>
+        <Link
+          to="/client/new" // Or a dedicated add client route, for now a placeholder
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full shadow-lg transition duration-150 ease-in-out"
+        >
+          + Add Client
+        </Link>
+      </div>
+
+      {isLoading && (
+        <div className="text-center py-10">
+          <p className="text-xl text-gray-500">Loading clients...</p>
+          {/* You could add a spinner here */}
+        </div>
+      )}
+
+      {isError && (
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-6" role="alert">
+          <strong className="font-bold">Error!</strong>
+          <span className="block sm:inline"> {error?.message || 'Failed to fetch clients.'}</span>
+        </div>
+      )}
+
+      {clients && clients.length === 0 && !isLoading && !isError && (
+        <div className="text-center py-10">
+          <p className="text-xl text-gray-500">No clients found.</p>
+          <p className="mt-2 text-gray-400">Get started by adding a new client.</p>
+        </div>
+      )}
+
+      {clients && clients.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {clients.map((client) => (
+            <Link
+              key={client.id}
+              to={`/client/${client.id}`}
+              className="block p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 transition-shadow duration-150 ease-in-out"
+            >
+              <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900">{client.display_name}</h5>
+              {client.notes && (
+                <p className="font-normal text-gray-700 mb-2 truncate">{client.notes}</p>
+              )}
+              <p className="text-sm text-gray-500">
+                Created: {new Date(client.created_at).toLocaleDateString()}
+              </p>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ClientListPage;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,48 @@
+export interface ClientRead {
+  id: string; // UUID
+  display_name: string;
+  notes?: string | null;
+  created_at: string; // ISO datetime string
+}
+
+// Add other shared types here as needed
+// For example, for API error responses (if standardized)
+export interface ApiError {
+  message: string;
+  details?: any;
+}
+
+export enum RoleStatus {
+  Pending = "Pending",           // Initial state before parsing
+  Parsed = "Parsed",             // Successfully parsed from input_text by LLM
+  InputCurated = "InputCurated",   // User has curated the input_text_compact for this role
+  RolesVerified = "RolesVerified", // User has verified/edited the role fields (company, title, dates)
+  CompanyVerified = "CompanyVerified", // User has verified/edited company details (not part of role editing)
+  Processing = "Processing",       // Input text is currently being processed (e.g., by LLM)
+  Failed = "Failed",               // Processing failed
+}
+
+export interface RoleRead {
+  id: string; // UUID
+  client_id: string; // UUID, Foreign Key to Client
+  company_name: string;
+  title: string;
+  start_date?: string | null; // Date as string (e.g., "YYYY-MM-DD")
+  end_date?: string | null; // Date as string (e.g., "YYYY-MM-DD")
+  output_text: string; // The raw text output from the LLM for this role
+  status: RoleStatus;
+  input_text_compact?: string | null; // Compacted input text for this role, if HITL editing was done
+  revision: number; // For optimistic locking
+  created_at: string; // ISO datetime string
+  updated_at: string; // ISO datetime string
+}
+
+export interface RoleUpdate {
+  company_name?: string;
+  title?: string;
+  start_date?: string | null;
+  end_date?: string | null;
+  input_text_compact?: string | null;
+  status?: RoleStatus | null;
+  revision: number; // Must be included for updates
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'system-ui', 'Avenir', 'Helvetica', 'Arial', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "vite.config.ts", "postcss.config.js", "tailwind.config.js"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts", "postcss.config.js", "tailwind.config.js"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import eslint from 'vite-plugin-eslint';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    react(),
+    eslint({
+      cache: false,
+      include: ['./src/**/*.ts', './src/**/*.tsx'],
+      exclude: [],
+    }),
+  ],
+  server: {
+    port: 3000, // Optional: specify a port
+  }
+})


### PR DESCRIPTION
I've implemented the initial React SPA structure for the Dataset Distiller frontend, fulfilling the M5 milestone requirements.

Key features include:
- Client List Page: Fetches and displays clients from the API using TanStack Query, with navigation to individual client detail pages.
- Client Detail/Role Verification Page: Displays client details and associated roles. Allows editing of core role information (company, title, dates) and updates the role status to 'RolesVerified' via API calls, handling revisions for optimistic locking.
- Role Editor Component: Provides a textarea for curating 'input_text_compact', featuring a live (estimated) token counter and PII pattern warnings. Saving curated text updates the role status to 'InputCurated'.
- Basic styling with Tailwind CSS is applied across the new components.
- TanStack Query is integrated for server state management.

I've developed and configured Playwright E2E tests for the UI happy paths (client listing, role verification, role curation). However, full execution of these tests timed out in the development environment, so I couldn't definitively verify that the Playwright happy-path passes. The test scripts and necessary configurations are included.

I created or updated the following files and structures:
- frontend/src/App.tsx (routing setup)
- frontend/src/main.tsx (QueryClientProvider, Tailwind CSS import)
- frontend/src/pages/ClientListPage.tsx
- frontend/src/pages/ClientDetailPage.tsx
- frontend/src/components/RoleEditor.tsx
- frontend/src/types.ts (ClientRead, RoleRead, RoleUpdate, RoleStatus)
- frontend/tailwind.config.js, frontend/postcss.config.js, frontend/src/index.css
- frontend/e2e/happy-path.spec.ts (Playwright tests)
- frontend/playwright.config.ts
- README.md (updated with E2E test instructions)